### PR TITLE
Hotfix posts #25

### DIFF
--- a/src/actions/post.js
+++ b/src/actions/post.js
@@ -25,7 +25,6 @@ export function readPosts() {
 }
 
 export function readMorePosts(startId) {
-  console.log('readMorePosts',startId);
   const request = api.get(`/posts?_start=${startId}&_limit=${OFFSET}`)
   return {
     type: READ_MORE_POSTS,

--- a/src/actions/post.js
+++ b/src/actions/post.js
@@ -2,6 +2,7 @@ import { api } from  './api';
 
 export const CREATE_POST = 'CREATE_POST';
 export const READ_POSTS = 'READ_POSTS';
+export const READ_MORE_POSTS = 'READ_MORE_POSTS';
 export const READ_POST  = 'READ_POST';
 export const DELETE_POST = 'DELETE_POST';
 
@@ -15,10 +16,19 @@ export function createPost(post) {
   }
 }
 
-export function readPosts(startId) {
-  const request = api.get(`/posts?_start=${startId}&_limit=${OFFSET}`)
+export function readPosts() {
+  const request = api.get(`/posts?_start=0&_limit=${OFFSET}`)
   return {
     type: READ_POSTS,
+    payload: request
+  };
+}
+
+export function readMorePosts(startId) {
+  console.log('readMorePosts',startId);
+  const request = api.get(`/posts?_start=${startId}&_limit=${OFFSET}`)
+  return {
+    type: READ_MORE_POSTS,
     payload: request
   };
 }

--- a/src/containers/Posts/Posts.js
+++ b/src/containers/Posts/Posts.js
@@ -19,8 +19,7 @@ class Posts extends React.Component {
   }
 
   onReadPosts() {
-    let startId = this.props.posts.length;
-    console.log(startId);
+    const startId = this.props.posts.length;
     this.props.readMorePosts(startId);
   }
 

--- a/src/containers/Posts/Posts.js
+++ b/src/containers/Posts/Posts.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Link } from 'react-router'
 
-import { readPosts } from './../../actions';
+import { readPosts, readMorePosts } from './../../actions';
 
 import { PostItem } from './../../components';
 
@@ -11,17 +11,21 @@ class Posts extends React.Component {
   constructor(props){
     super(props);
 
-    this.props.readPosts(0);
     this.onReadPosts = this.onReadPosts.bind(this);
   }
 
-  onReadPosts(postLength) {
-    this.props.readPosts(postLength);
+  componentWillMount(){
+    this.props.readPosts();
+  }
+
+  onReadPosts() {
+    let startId = this.props.posts.length;
+    console.log(startId);
+    this.props.readMorePosts(startId);
   }
 
   render() {
     let posts = this.props.posts.map((post) => <PostItem key={post.id} {...post} />);
-    let startId = this.props.posts.length;
     return (
       <div>
         <h1 className="text-center"> {window.location.pathname} </h1>
@@ -35,7 +39,7 @@ class Posts extends React.Component {
         </div>
 
         <button className="col-md-12 btn btn-default"
-          onClick={() => this.onReadPosts(startId)}>
+          onClick={() => this.onReadPosts()}>
           로오딩
         </button>
       </div>
@@ -50,7 +54,7 @@ function mapStateToProps(state) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ readPosts }, dispatch);
+  return bindActionCreators({ readPosts, readMorePosts }, dispatch);
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(Posts);

--- a/src/reducers/post.js
+++ b/src/reducers/post.js
@@ -1,4 +1,4 @@
-import { CREATE_POST, READ_POSTS, READ_POST, DELETE_POST } from './../actions';
+import { CREATE_POST, READ_POSTS, READ_MORE_POSTS, READ_POST, DELETE_POST } from './../actions';
 
 const INITIAL_POST_STATE = { list: [], detail: {} };
 
@@ -7,7 +7,9 @@ export default function (state = INITIAL_POST_STATE, action) {
     case CREATE_POST:
       return state;
     case READ_POSTS:
-      return {...state, list: state.list.concat(...action.payload.data) };
+      return {...state, list: action.payload.data };
+    case READ_MORE_POSTS:
+      return {...state, list: state.list.concat(action.payload.data) };
     case READ_POST:
       return {...state, detail: action.payload.data };
     case DELETE_POST:


### PR DESCRIPTION
# issue https://github.com/pjhjohn/jsonplaceholder-client/issues/25

기존의 action는 아래와 같이 작동한다.

``` javascript
case READ_POSTS:
      return {...state, list: state.list.concat(...action.payload.data) };
```

이 경우에 액션이 계속 호출 되면
1  
1 2
1 2 3  
와 같은 값을 계속 보내게되는데 이미 캐싱된 state와 겹치는 데이터가 생겨 워닝이 발생했다.
그래서 액션을 나눠서 작업함

``` javascript
case READ_POSTS:
      return {...state, list: action.payload.data };
case READ_MORE_POSTS:
      return {...state, list: state.list.concat(action.payload.data) };
```

---

그리고 제가 작성한 액션 이름과 함수 이름이 적절하지 않은 것 같은 생각이 듭니다.
